### PR TITLE
feat: implement reusable ConfirmationModal for account deletion and data clear

### DIFF
--- a/src/components/BalanceSheet.tsx
+++ b/src/components/BalanceSheet.tsx
@@ -216,8 +216,17 @@ export const BalanceSheet: React.FC = () => {
             setAccountToDelete(null);
           }
         }}
-        title={accountToDelete?.name.toLowerCase().includes('card') ? 'Delete Card' : 'Delete Account'}
-        message={`Are you sure you want to delete "${accountToDelete?.name}"? This will also remove all associated balance history. This action cannot be undone.`}
+        title={
+          accountToDelete?.category === 'Credit Cards'
+            ? 'Remove Card Record'
+            : accountToDelete?.category === 'Cash and Cash Equivalents'
+              ? 'Remove Cash Account'
+              : `Remove ${accountToDelete?.category || 'Account'} Record`
+        }
+        message={`Are you sure you want to delete "${accountToDelete?.name && accountToDelete.name.length > 50
+          ? accountToDelete.name.substring(0, 50) + '...'
+          : accountToDelete?.name
+          }"? This will also remove all associated balance history. This action cannot be undone.`}
         confirmText="Delete"
         variant="danger"
       />

--- a/src/components/BalanceSheet.tsx
+++ b/src/components/BalanceSheet.tsx
@@ -7,12 +7,14 @@ import { useCurrency } from '@/context/CurrencyContext';
 import { CurrencySelector } from './CurrencySelector';
 import WelcomeScreen from './WelcomeScreen';
 import { ManageAccountModal } from './ManageAccountModal';
+import { ConfirmationModal } from './ui/ConfirmationModal';
 
 export const BalanceSheet: React.FC = () => {
   const { getAccountsWithBalances, deleteAccount, updateAccount, isLoading } = useFinance();
   const { formatCurrency } = useCurrency();
   const accountsWithBalances = getAccountsWithBalances();
   const [editingAccount, setEditingAccount] = useState<Account | null>(null);
+  const [accountToDelete, setAccountToDelete] = useState<Account | null>(null);
 
   const handleSaveAccount = (updates: Pick<Account, 'name' | 'category' | 'type'>) => {
     if (!editingAccount) return;
@@ -66,9 +68,8 @@ export const BalanceSheet: React.FC = () => {
               >
                 <span className="text-gray-800">{account.name}</span>
                 <div className="flex items-center space-x-2">
-                  <span className={`font-medium ${
-                    account.currentBalance >= 0 ? 'text-green-600' : 'text-red-600'
-                  }`}>
+                  <span className={`font-medium ${account.currentBalance >= 0 ? 'text-green-600' : 'text-red-600'
+                    }`}>
                     {formatCurrency(account.currentBalance)}
                   </span>
                   <button
@@ -79,7 +80,7 @@ export const BalanceSheet: React.FC = () => {
                     Edit
                   </button>
                   <button
-                    onClick={() => deleteAccount(account.id)}
+                    onClick={() => setAccountToDelete(account)}
                     className="text-red-500 hover:text-red-700 text-sm px-2 py-1 rounded hover:bg-red-50 transition-colors"
                     title="Delete account"
                   >
@@ -205,6 +206,21 @@ export const BalanceSheet: React.FC = () => {
           onSave={handleSaveAccount}
         />
       )}
+
+      <ConfirmationModal
+        isOpen={!!accountToDelete}
+        onClose={() => setAccountToDelete(null)}
+        onConfirm={() => {
+          if (accountToDelete) {
+            deleteAccount(accountToDelete.id);
+            setAccountToDelete(null);
+          }
+        }}
+        title={accountToDelete?.name.toLowerCase().includes('card') ? 'Delete Card' : 'Delete Account'}
+        message={`Are you sure you want to delete "${accountToDelete?.name}"? This will also remove all associated balance history. This action cannot be undone.`}
+        confirmText="Delete"
+        variant="danger"
+      />
     </div>
   );
 };

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -6,6 +6,7 @@ import { useCurrency } from '@/context/CurrencyContext';
 import { useAuth } from '@/context/AuthContext';
 import { CurrencySelector } from './CurrencySelector';
 import { CloudSyncToggle } from './CloudSyncToggle';
+import { ConfirmationModal } from './ui/ConfirmationModal';
 
 const Settings: React.FC = () => {
   const {
@@ -241,53 +242,31 @@ const Settings: React.FC = () => {
       </div>
 
       {/* Danger Zone */}
-      <div className="bg-red-50 rounded-lg p-6 border border-red-200">
-        <h2 className="text-xl font-semibold text-red-800 mb-4">⚠️ Danger Zone</h2>
-        <p className="text-red-700 mb-4">
+      <div className="bg-red-50 dark:bg-red-900/10 rounded-lg p-6 border border-red-200 dark:border-red-900/30">
+        <h2 className="text-xl font-semibold text-red-800 dark:text-red-400 mb-4">⚠️ Danger Zone</h2>
+        <p className="text-red-700 dark:text-red-300 mb-4">
           Permanently delete all your financial data. This action cannot be undone.
         </p>
 
-        {!showConfirmDelete ? (
-          <button
-            onClick={() => setShowConfirmDelete(true)}
-            className="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded-md font-medium transition-colors flex items-center space-x-2"
-          >
-            <span>🗑️</span>
-            <span>Clear All Data</span>
-          </button>
-        ) : (
-          <div className="space-y-4">
-            <div className="bg-red-100 border border-red-300 rounded-md p-4">
-              <p className="text-red-800 font-medium">
-                Are you sure you want to delete all data? This will permanently remove:
-              </p>
-              <ul className="list-disc list-inside text-red-700 mt-2 space-y-1">
-                <li>{dataStats.accountsCount} accounts</li>
-                <li>{dataStats.balancesCount} balance records</li>
-                <li>All historical tracking data</li>
-              </ul>
-              <p className="text-red-800 font-medium mt-3">
-                This action cannot be undone!
-              </p>
-            </div>
-
-            <div className="flex space-x-3">
-              <button
-                onClick={handleClearAllData}
-                className="bg-red-700 hover:bg-red-800 text-white px-6 py-2 rounded-md font-medium transition-colors"
-              >
-                Yes, Delete Everything
-              </button>
-              <button
-                onClick={() => setShowConfirmDelete(false)}
-                className="bg-gray-300 hover:bg-gray-400 text-gray-700 px-6 py-2 rounded-md font-medium transition-colors"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        )}
+        <button
+          onClick={() => setShowConfirmDelete(true)}
+          className="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded-xl font-bold transition-all active:scale-[0.98] flex items-center space-x-2 shadow-lg shadow-red-200 dark:shadow-none"
+        >
+          <span>🗑️</span>
+          <span>Clear All Data</span>
+        </button>
       </div>
+
+      <ConfirmationModal
+        isOpen={showConfirmDelete}
+        onClose={() => setShowConfirmDelete(false)}
+        onConfirm={handleClearAllData}
+        title="Clear All Data"
+        message={`This will permanently remove ${dataStats.accountsCount} accounts and ${dataStats.balancesCount} balance records. This action is irreversible.`}
+        confirmText="Yes, Delete Everything"
+        variant="danger"
+        requiresChallenge={true}
+      />
     </div>
   );
 };

--- a/src/components/ui/ConfirmationModal.tsx
+++ b/src/components/ui/ConfirmationModal.tsx
@@ -1,0 +1,196 @@
+'use client';
+import React, { useEffect, useState, useRef } from 'react';
+
+interface ConfirmationModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    title: string;
+    message: string;
+    confirmText?: string;
+    cancelText?: string;
+    variant?: 'danger' | 'warning' | 'info';
+    requiresChallenge?: boolean;
+}
+
+export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
+    isOpen,
+    onClose,
+    onConfirm,
+    title,
+    message,
+    confirmText = 'Confirm',
+    cancelText = 'Cancel',
+    variant = 'danger',
+    requiresChallenge = false,
+}) => {
+    const [challengeValue, setChallengeValue] = useState('');
+    const [isRendered, setIsRendered] = useState(false);
+    const modalRef = useRef<HTMLDivElement>(null);
+    const previousFocusRef = useRef<HTMLElement | null>(null);
+
+    // Handle Open/Close state and Focus Management
+    useEffect(() => {
+        if (isOpen) {
+            previousFocusRef.current = document.activeElement as HTMLElement;
+            setIsRendered(true);
+            document.body.style.overflow = 'hidden';
+
+            // Slight delay to ensure focusable elements are in DOM
+            const timer = setTimeout(() => {
+                const focusableElements = modalRef.current?.querySelectorAll(
+                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+                );
+                if (focusableElements && focusableElements.length > 0) {
+                    (focusableElements[0] as HTMLElement).focus();
+                }
+            }, 50);
+            return () => clearTimeout(timer);
+        } else {
+            const timer = setTimeout(() => setIsRendered(false), 300);
+            document.body.style.overflow = 'unset';
+
+            // Restore focus
+            if (previousFocusRef.current) {
+                previousFocusRef.current.focus();
+            }
+
+            return () => clearTimeout(timer);
+        }
+    }, [isOpen]);
+
+    // Focus Trapping Logic
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (!isOpen) return;
+
+            if (e.key === 'Escape') {
+                onClose();
+                return;
+            }
+
+            if (e.key === 'Tab') {
+                const focusableElements = modalRef.current?.querySelectorAll(
+                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+                );
+
+                if (!focusableElements || focusableElements.length === 0) return;
+
+                const firstElement = focusableElements[0] as HTMLElement;
+                const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+                if (e.shiftKey) { // Shift + Tab
+                    if (document.activeElement === firstElement) {
+                        e.preventDefault();
+                        lastElement.focus();
+                    }
+                } else { // Tab
+                    if (document.activeElement === lastElement) {
+                        e.preventDefault();
+                        firstElement.focus();
+                    }
+                }
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen, onClose]);
+
+    if (!isRendered) return null;
+
+    const getVariantStyles = () => {
+        switch (variant) {
+            case 'danger':
+                return {
+                    icon: '⚠️',
+                    button: 'bg-red-600 hover:bg-red-700 text-white shadow-xl shadow-red-100',
+                    titleColor: 'text-red-800',
+                };
+            case 'warning':
+                return {
+                    icon: '🔸',
+                    button: 'bg-amber-500 hover:bg-amber-600 text-white shadow-xl shadow-amber-100',
+                    titleColor: 'text-amber-800',
+                };
+            default:
+                return {
+                    icon: 'ℹ️',
+                    button: 'bg-blue-600 hover:bg-blue-700 text-white shadow-xl shadow-blue-100',
+                    titleColor: 'text-blue-800',
+                };
+        }
+    };
+
+    const styles = getVariantStyles();
+    const isConfirmDisabled = requiresChallenge && challengeValue !== 'DELETE';
+
+    return (
+        <div
+            className={`fixed inset-0 z-50 flex items-center justify-center p-4 transition-opacity duration-300 ${isOpen ? 'opacity-100' : 'opacity-0'
+                }`}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="modal-title"
+            aria-describedby="modal-description"
+        >
+            {/* Backdrop */}
+            <div
+                className="fixed inset-0 bg-neutral-900/30 backdrop-blur-sm transition-opacity"
+                onClick={onClose}
+            />
+
+            {/* Modal Container */}
+            <div
+                ref={modalRef}
+                className={`relative w-full max-w-md transform overflow-hidden rounded-3xl bg-white p-8 shadow-[0_20px_50px_rgba(0,0,0,0.15)] transition-all duration-300 border border-neutral-100 ${isOpen ? 'scale-100 translate-y-0 opacity-100' : 'scale-95 translate-y-4 opacity-0'
+                    }`}
+            >
+                <div className="flex items-center space-x-3 mb-4">
+                    <span className="text-2xl" aria-hidden="true">{styles.icon}</span>
+                    <h3 id="modal-title" className={`text-2xl font-black tracking-tight ${styles.titleColor}`}>
+                        {title}
+                    </h3>
+                </div>
+
+                <p id="modal-description" className="text-neutral-600 mb-8 leading-relaxed text-lg">
+                    {message}
+                </p>
+
+                {requiresChallenge && (
+                    <div className="mb-8">
+                        <label className="block text-sm font-bold text-neutral-500 uppercase tracking-wider mb-2">
+                            Type <span className="text-red-600">DELETE</span> to confirm
+                        </label>
+                        <input
+                            type="text"
+                            value={challengeValue}
+                            onChange={(e) => setChallengeValue(e.target.value)}
+                            placeholder="DELETE"
+                            className="w-full px-5 py-4 rounded-2xl border-2 border-neutral-100 bg-neutral-50 text-neutral-900 focus:border-red-500 focus:ring-0 transition-all outline-none font-bold text-lg placeholder:text-neutral-300"
+                        />
+                    </div>
+                )}
+
+                <div className="flex flex-col sm:flex-row-reverse gap-4">
+                    <button
+                        onClick={() => {
+                            onConfirm();
+                            setChallengeValue('');
+                        }}
+                        disabled={isConfirmDisabled}
+                        className={`flex-[2] py-4 rounded-2xl font-bold text-lg transition-all active:scale-[0.98] cursor-pointer disabled:opacity-30 disabled:grayscale disabled:cursor-not-allowed ${styles.button}`}
+                    >
+                        {confirmText}
+                    </button>
+                    <button
+                        onClick={onClose}
+                        className="flex-1 py-4 rounded-2xl font-bold text-lg bg-neutral-100 text-neutral-600 hover:bg-neutral-200 cursor-pointer transition-all active:scale-[0.98]"
+                    >
+                        {cancelText}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
- Created a reusable safety modal to handle destructive actions.
- Added confirmation popups to the Balance Sheet when deleting accounts.
- Updated Settings to require typing "DELETE" to confirm clearing all data.
- Added full keyboard and screen reader accessibility support.
- Improved the overall UI look and feel for better experience.