### PR TITLE
Feat: Better Currency Picker with Flags and Search

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -220,3 +220,12 @@ input:not(:placeholder-shown) {
   color: #f3f4f6 !important;
   /* gray-100 */
 }
+
+/* ── Scrollbar-hide utility (used on region tabs strip) ─────────────────── */
+.scrollbar-hide {
+  scrollbar-width: none;        /* Firefox */
+  -ms-overflow-style: none;     /* IE / Edge */
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;                /* Chrome / Safari / Opera */
+}

--- a/src/components/BalanceSheet.tsx
+++ b/src/components/BalanceSheet.tsx
@@ -141,7 +141,7 @@ export const BalanceSheet = () => {
         </div>
         {/* Currency Selection */}
         <div className="mb-8 flex justify-end">
-          <CurrencySelector size="sm" />
+          <CurrencySelector showLabel={false} />
         </div>
         {groupedAccounts.asset && (
           <AccountSection

--- a/src/components/CurrencySelector.tsx
+++ b/src/components/CurrencySelector.tsx
@@ -1,66 +1,401 @@
 'use client';
 
-import React from 'react';
-import { useCurrency, SUPPORTED_CURRENCIES } from '@/context/CurrencyContext';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import {
+  useCurrency,
+  SUPPORTED_CURRENCIES,
+  CURRENCY_REGIONS,
+  getCurrenciesByRegion,
+  type Currency,
+} from '@/context/CurrencyContext';
 import { useAnalytics } from '@/hooks/useAnalytics';
 
 interface CurrencySelectorProps {
   className?: string;
-  size?: 'sm' | 'md' | 'lg';
   showLabel?: boolean;
 }
 
 export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
   className = '',
-  size = 'md',
-  showLabel = true
+  showLabel = true,
 }) => {
   const { selectedCurrency, setSelectedCurrency } = useCurrency();
   const { trackEvent } = useAnalytics();
 
-  const sizeClasses = {
-    sm: 'px-2 py-1 text-sm',
-    md: 'px-3 py-2 text-sm',
-    lg: 'px-4 py-3 text-base'
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [activeRegion, setActiveRegion] = useState<string>('All');
+
+  // Arrow visibility state
+  const [showLeftArrow, setShowLeftArrow] = useState(false);
+  const [showRightArrow, setShowRightArrow] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const tabsRef = useRef<HTMLDivElement>(null);
+
+  // ── Outside click ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+        setSearch('');
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // ── Auto-focus search ──────────────────────────────────────────────────────
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => searchRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  // ── Escape key ────────────────────────────────────────────────────────────
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+        setSearch('');
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, []);
+
+  // ── Region-tabs scroll arrows ──────────────────────────────────────────────
+  const updateArrows = useCallback(() => {
+    const el = tabsRef.current;
+    if (!el) return;
+    setShowLeftArrow(el.scrollLeft > 4);
+    setShowRightArrow(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
+  }, []);
+
+  useEffect(() => {
+    const el = tabsRef.current;
+    if (!el) return;
+    updateArrows();
+    el.addEventListener('scroll', updateArrows, { passive: true });
+    const ro = new ResizeObserver(updateArrows);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener('scroll', updateArrows);
+      ro.disconnect();
+    };
+  }, [updateArrows, isOpen]);
+
+  const scrollTabs = (dir: 'left' | 'right') => {
+    const el = tabsRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir === 'left' ? -120 : 120, behavior: 'smooth' });
   };
 
-  const handleCurrencyChange = (currencyCode: string) => {
-    const currency = SUPPORTED_CURRENCIES.find(c => c.code === currencyCode);
-    if (currency) {
-      setSelectedCurrency(currency);
-      // Track currency change
+  // ── Currency select ────────────────────────────────────────────────────────
+  const handleSelect = useCallback(
+    (currency: Currency) => {
       trackEvent('currency_changed', {
         from_currency: selectedCurrency.code,
         to_currency: currency.code,
       });
-    }
-  };
+      setSelectedCurrency(currency);
+      setIsOpen(false);
+      setSearch('');
+    },
+    [selectedCurrency.code, setSelectedCurrency, trackEvent]
+  );
+
+  // ── Filtering ─────────────────────────────────────────────────────────────
+  const query = search.toLowerCase().trim();
+  const filteredCurrencies = SUPPORTED_CURRENCIES.filter((c) => {
+    const matchesSearch =
+      !query ||
+      c.code.toLowerCase().includes(query) ||
+      c.name.toLowerCase().includes(query) ||
+      c.symbol.toLowerCase().includes(query) ||
+      c.region.toLowerCase().includes(query);
+    const matchesRegion = activeRegion === 'All' || c.region === activeRegion;
+    return matchesSearch && matchesRegion;
+  });
+
+  // ── Grouping ──────────────────────────────────────────────────────────────
+  const regionGroups: { region: string; currencies: Currency[] }[] = [];
+  if (activeRegion === 'All' && !query) {
+    CURRENCY_REGIONS.forEach((region) => {
+      regionGroups.push({ region, currencies: getCurrenciesByRegion(region) });
+    });
+  } else {
+    regionGroups.push({ region: '', currencies: filteredCurrencies });
+  }
+
+  const regions = ['All', ...CURRENCY_REGIONS];
 
   return (
-    <div className={`flex flex-col ${className}`}>
+    <div className={`relative ${className}`} ref={containerRef}>
       {showLabel && (
-        <label htmlFor="currency-select" className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+        <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1.5">
           Currency
         </label>
       )}
-      <select
+
+      {/* ── Trigger button ─────────────────────────────────────────────────── */}
+      <button
         id="currency-select"
-        value={selectedCurrency.code}
-        onChange={(e) => handleCurrencyChange(e.target.value)}
-        className={`
-          ${sizeClasses[size]}
-          border border-gray-300 dark:border-neutral-600 rounded-md shadow-sm 
+        type="button"
+        onClick={() => setIsOpen((o) => !o)}
+        className="
+          w-full flex items-center justify-between gap-3
+          px-3 py-2.5 rounded-lg
+          border border-gray-300 dark:border-neutral-600
+          bg-white dark:bg-neutral-800
+          text-gray-900 dark:text-neutral-100
+          shadow-sm hover:border-blue-400 dark:hover:border-blue-500
           focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
-          bg-white dark:bg-neutral-700 text-gray-900 dark:text-neutral-100
-          ${className}
-        `}
+          transition-all duration-150
+          text-sm font-medium
+        "
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
       >
-        {SUPPORTED_CURRENCIES.map((currency) => (
-          <option key={currency.code} value={currency.code}>
-            {currency.symbol} {currency.code} - {currency.name}
-          </option>
-        ))}
-      </select>
+        <span className="flex items-center gap-2.5 min-w-0">
+          <span className="text-xl leading-none shrink-0">{selectedCurrency.flag}</span>
+          <span className="truncate">{selectedCurrency.code}</span>
+          <span className="text-gray-400 dark:text-neutral-500 font-normal truncate hidden sm:inline">
+            — {selectedCurrency.name}
+          </span>
+        </span>
+        <span
+          className={`shrink-0 text-gray-400 dark:text-neutral-500 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''
+            }`}
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+            <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+      </button>
+
+      {/* ── Dropdown panel ─────────────────────────────────────────────────── */}
+      {isOpen && (
+        <div
+          className="
+            absolute z-50 mt-2 w-full min-w-[320px] max-w-md
+            bg-white dark:bg-neutral-900
+            border border-gray-200 dark:border-neutral-700
+            rounded-xl shadow-xl shadow-black/10 dark:shadow-black/40
+            flex flex-col overflow-hidden
+          "
+          style={{ maxHeight: '400px' }}
+          role="listbox"
+          aria-label="Select currency"
+        >
+          {/* Search + tab strip */}
+          <div className="p-3 border-b border-gray-100 dark:border-neutral-800">
+
+            {/* Search field */}
+            <div className="relative">
+              <svg
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-neutral-500"
+                width="15" height="15" viewBox="0 0 15 15" fill="none" aria-hidden
+              >
+                <path
+                  d="M10 6.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0ZM9.5 10.207l2.646 2.646"
+                  stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"
+                />
+              </svg>
+              <input
+                ref={searchRef}
+                type="text"
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.target.value);
+                  setActiveRegion('All');
+                }}
+                placeholder="Search currency, code or region…"
+                className="
+                  w-full pl-9 pr-3 py-2 text-sm rounded-lg
+                  bg-gray-50 dark:bg-neutral-800
+                  border border-gray-200 dark:border-neutral-700
+                  text-gray-900 dark:text-neutral-100
+                  placeholder:text-gray-400 dark:placeholder:text-neutral-500
+                  focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                  transition-all
+                "
+              />
+              {search && (
+                <button
+                  onClick={() => setSearch('')}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300 transition-colors"
+                >
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+                    <path d="M3 3l8 8M11 3l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                  </svg>
+                </button>
+              )}
+            </div>
+
+            {/* Region tabs — hidden scrollbar + fade-edge arrows */}
+            {!query && (
+              <div className="relative mt-2.5">
+
+                {/* Left fade + arrow */}
+                {showLeftArrow && (
+                  <div className="
+                    absolute left-0 top-0 bottom-0 z-10
+                    w-10 flex items-center justify-start
+                    pointer-events-none
+                    bg-gradient-to-r from-white dark:from-neutral-900 to-transparent
+                  ">
+                    <button
+                      onClick={() => scrollTabs('left')}
+                      aria-label="Scroll regions left"
+                      className="
+                        pointer-events-auto
+                        flex items-center justify-center
+                        w-5 h-5 rounded-full ml-0.5
+                        bg-gray-100 dark:bg-neutral-700
+                        text-gray-500 dark:text-neutral-400
+                        hover:bg-gray-200 dark:hover:bg-neutral-600
+                        hover:text-gray-700 dark:hover:text-neutral-200
+                        transition-all duration-150
+                      "
+                    >
+                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
+                        <path d="M7.5 2L4 6l3.5 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </button>
+                  </div>
+                )}
+
+                {/* Scrollable tabs strip */}
+                <div
+                  ref={tabsRef}
+                  className={`
+                    scrollbar-hide flex gap-1.5 overflow-x-auto
+                    ${showLeftArrow ? 'pl-8' : ''}
+                    ${showRightArrow ? 'pr-8' : ''}
+                  `}
+                >
+                  {regions.map((region) => (
+                    <button
+                      key={region}
+                      onClick={() => setActiveRegion(region)}
+                      className={`
+                        shrink-0 px-2.5 py-1 text-xs rounded-full font-medium transition-all duration-150
+                        ${activeRegion === region
+                          ? 'bg-blue-600 text-white shadow-sm'
+                          : 'bg-gray-100 dark:bg-neutral-800 text-gray-600 dark:text-neutral-400 hover:bg-gray-200 dark:hover:bg-neutral-700'
+                        }
+                      `}
+                    >
+                      {region}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Right fade + arrow */}
+                {showRightArrow && (
+                  <div className="
+                    absolute right-0 top-0 bottom-0 z-10
+                    w-10 flex items-center justify-end
+                    pointer-events-none
+                    bg-gradient-to-l from-white dark:from-neutral-900 to-transparent
+                  ">
+                    <button
+                      onClick={() => scrollTabs('right')}
+                      aria-label="Scroll regions right"
+                      className="
+                        pointer-events-auto
+                        flex items-center justify-center
+                        w-5 h-5 rounded-full mr-0.5
+                        bg-gray-100 dark:bg-neutral-700
+                        text-gray-500 dark:text-neutral-400
+                        hover:bg-gray-200 dark:hover:bg-neutral-600
+                        hover:text-gray-700 dark:hover:text-neutral-200
+                        transition-all duration-150
+                      "
+                    >
+                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
+                        <path d="M4.5 2L8 6l-3.5 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* ── Currency list ───────────────────────────────────────────────── */}
+          <div className="overflow-y-auto flex-1">
+            {filteredCurrencies.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-10 text-gray-400 dark:text-neutral-500">
+                <span className="text-3xl mb-2">🔍</span>
+                <p className="text-sm">No currencies match &ldquo;{search}&rdquo;</p>
+              </div>
+            ) : (
+              regionGroups.map(({ region, currencies }) =>
+                currencies.length === 0 ? null : (
+                  <div key={region || 'results'}>
+                    {region && (
+                      <div className="sticky top-0 px-3 py-1.5 bg-gray-50 dark:bg-neutral-800/80 backdrop-blur-sm border-b border-gray-100 dark:border-neutral-700/50">
+                        <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-neutral-500">
+                          {region}
+                        </span>
+                      </div>
+                    )}
+                    {currencies.map((currency) => {
+                      const isSelected = selectedCurrency.code === currency.code;
+                      return (
+                        <button
+                          key={currency.code}
+                          role="option"
+                          aria-selected={isSelected}
+                          onClick={() => handleSelect(currency)}
+                          className={`
+                            w-full flex items-center gap-3 px-3 py-2.5
+                            text-left text-sm transition-colors duration-100
+                            ${isSelected
+                              ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
+                              : 'text-gray-800 dark:text-neutral-200 hover:bg-gray-50 dark:hover:bg-neutral-800'
+                            }
+                          `}
+                        >
+                          <span className="text-xl leading-none shrink-0 w-7 text-center">
+                            {currency.flag}
+                          </span>
+                          <span className="flex-1 min-w-0">
+                            <span className="font-semibold">{currency.code}</span>
+                            <span className="ml-2 text-gray-500 dark:text-neutral-400 font-normal truncate">
+                              {currency.name}
+                            </span>
+                          </span>
+                          <span className="shrink-0 text-xs font-mono text-gray-400 dark:text-neutral-500">
+                            {currency.symbol}
+                          </span>
+                          {isSelected && (
+                            <span className="shrink-0 text-blue-600 dark:text-blue-400">
+                              <svg width="15" height="15" viewBox="0 0 15 15" fill="none" aria-hidden>
+                                <path d="M3 8l3 3 6-6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )
+              )
+            )}
+          </div>
+
+          {/* ── Footer count ────────────────────────────────────────────────── */}
+          <div className="px-3 py-2 border-t border-gray-100 dark:border-neutral-800 bg-gray-50 dark:bg-neutral-900">
+            <p className="text-xs text-gray-400 dark:text-neutral-500 text-center">
+              {filteredCurrencies.length} of {SUPPORTED_CURRENCIES.length} currencies
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/CurrencySelector.tsx
+++ b/src/components/CurrencySelector.tsx
@@ -25,6 +25,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [activeRegion, setActiveRegion] = useState<string>('All');
+  const [focusedIndex, setFocusedIndex] = useState(-1);
 
   // Arrow visibility state
   const [showLeftArrow, setShowLeftArrow] = useState(false);
@@ -33,6 +34,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const tabsRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   // ── Outside click ──────────────────────────────────────────────────────────
   useEffect(() => {
@@ -40,6 +42,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
         setSearch('');
+        setFocusedIndex(-1);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
@@ -50,20 +53,9 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
   useEffect(() => {
     if (isOpen) {
       setTimeout(() => searchRef.current?.focus(), 50);
+      setFocusedIndex(-1);
     }
   }, [isOpen]);
-
-  // ── Escape key ────────────────────────────────────────────────────────────
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setIsOpen(false);
-        setSearch('');
-      }
-    };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, []);
 
   // ── Region-tabs scroll arrows ──────────────────────────────────────────────
   const updateArrows = useCallback(() => {
@@ -102,6 +94,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
       setSelectedCurrency(currency);
       setIsOpen(false);
       setSearch('');
+      setFocusedIndex(-1);
     },
     [selectedCurrency.code, setSelectedCurrency, trackEvent]
   );
@@ -119,6 +112,48 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
     return matchesSearch && matchesRegion;
   });
 
+  // Reset focused index when list changes
+  useEffect(() => {
+    setFocusedIndex(-1);
+  }, [query, activeRegion]);
+
+  // ── Keyboard navigation ────────────────────────────────────────────────────
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.min(i + 1, filteredCurrencies.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (focusedIndex >= 0 && focusedIndex < filteredCurrencies.length) {
+        handleSelect(filteredCurrencies[focusedIndex]);
+      }
+    } else if (e.key === 'Escape') {
+      setIsOpen(false);
+      setSearch('');
+      setFocusedIndex(-1);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setFocusedIndex(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setFocusedIndex(filteredCurrencies.length - 1);
+    }
+  };
+
+  // Scroll focused item into view
+  useEffect(() => {
+    if (focusedIndex < 0 || !listRef.current) return;
+    const item = listRef.current.querySelector<HTMLElement>(
+      `[data-index="${focusedIndex}"]`
+    );
+    item?.scrollIntoView({ block: 'nearest' });
+  }, [focusedIndex]);
+
   // ── Grouping ──────────────────────────────────────────────────────────────
   const regionGroups: { region: string; currencies: Currency[] }[] = [];
   if (activeRegion === 'All' && !query) {
@@ -131,10 +166,17 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
 
   const regions = ['All', ...CURRENCY_REGIONS];
 
+  // Flat index map for keyboard nav (needed because of region group headers)
+  let flatIndex = -1;
+
   return (
     <div className={`relative ${className}`} ref={containerRef}>
+      {/* FIX #4: label is now associated with the trigger button via htmlFor */}
       {showLabel && (
-        <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1.5">
+        <label
+          htmlFor="currency-select"
+          className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1.5"
+        >
           Currency
         </label>
       )}
@@ -157,6 +199,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
         "
         aria-haspopup="listbox"
         aria-expanded={isOpen}
+        aria-controls="currency-listbox"
       >
         <span className="flex items-center gap-2.5 min-w-0">
           <span className="text-xl leading-none shrink-0">{selectedCurrency.flag}</span>
@@ -178,8 +221,10 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
       {/* ── Dropdown panel ─────────────────────────────────────────────────── */}
       {isOpen && (
         <div
+          id="currency-listbox"
           className="
-            absolute z-50 mt-2 w-full min-w-[320px] max-w-md
+            absolute z-50 mt-2 w-full min-w-[280px] max-w-md
+            right-0
             bg-white dark:bg-neutral-900
             border border-gray-200 dark:border-neutral-700
             rounded-xl shadow-xl shadow-black/10 dark:shadow-black/40
@@ -188,6 +233,9 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
           style={{ maxHeight: '400px' }}
           role="listbox"
           aria-label="Select currency"
+          aria-activedescendant={
+            focusedIndex >= 0 ? `currency-option-${filteredCurrencies[focusedIndex]?.code}` : undefined
+          }
         >
           {/* Search + tab strip */}
           <div className="p-3 border-b border-gray-100 dark:border-neutral-800">
@@ -206,14 +254,19 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
               <input
                 ref={searchRef}
                 type="text"
+                role="combobox"
+                aria-expanded={isOpen}
+                aria-controls="currency-listbox"
+                aria-autocomplete="list"
                 value={search}
                 onChange={(e) => {
                   setSearch(e.target.value);
                   setActiveRegion('All');
                 }}
+                onKeyDown={handleSearchKeyDown}
                 placeholder="Search currency, code or region…"
                 className="
-                  w-full pl-9 pr-3 py-2 text-sm rounded-lg
+                  w-full pl-9 pr-8 py-2 text-sm rounded-lg
                   bg-gray-50 dark:bg-neutral-800
                   border border-gray-200 dark:border-neutral-700
                   text-gray-900 dark:text-neutral-100
@@ -222,8 +275,11 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
                   transition-all
                 "
               />
+              {/* FIX #1: type="button" + aria-label added */}
               {search && (
                 <button
+                  type="button"
+                  aria-label="Clear search"
                   onClick={() => setSearch('')}
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300 transition-colors"
                 >
@@ -247,6 +303,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
                     bg-gradient-to-r from-white dark:from-neutral-900 to-transparent
                   ">
                     <button
+                      type="button"
                       onClick={() => scrollTabs('left')}
                       aria-label="Scroll regions left"
                       className="
@@ -279,6 +336,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
                   {regions.map((region) => (
                     <button
                       key={region}
+                      type="button"
                       onClick={() => setActiveRegion(region)}
                       className={`
                         shrink-0 px-2.5 py-1 text-xs rounded-full font-medium transition-all duration-150
@@ -302,6 +360,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
                     bg-gradient-to-l from-white dark:from-neutral-900 to-transparent
                   ">
                     <button
+                      type="button"
                       onClick={() => scrollTabs('right')}
                       aria-label="Scroll regions right"
                       className="
@@ -326,7 +385,7 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
           </div>
 
           {/* ── Currency list ───────────────────────────────────────────────── */}
-          <div className="overflow-y-auto flex-1">
+          <div className="overflow-y-auto flex-1" ref={listRef}>
             {filteredCurrencies.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-10 text-gray-400 dark:text-neutral-500">
                 <span className="text-3xl mb-2">🔍</span>
@@ -344,19 +403,28 @@ export const CurrencySelector: React.FC<CurrencySelectorProps> = ({
                       </div>
                     )}
                     {currencies.map((currency) => {
+                      flatIndex += 1;
+                      const currentIndex = flatIndex;
                       const isSelected = selectedCurrency.code === currency.code;
+                      const isFocused = focusedIndex === currentIndex;
                       return (
                         <button
                           key={currency.code}
+                          id={`currency-option-${currency.code}`}
+                          data-index={currentIndex}
+                          type="button"
                           role="option"
                           aria-selected={isSelected}
                           onClick={() => handleSelect(currency)}
+                          onMouseEnter={() => setFocusedIndex(currentIndex)}
                           className={`
                             w-full flex items-center gap-3 px-3 py-2.5
                             text-left text-sm transition-colors duration-100
-                            ${isSelected
-                              ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
-                              : 'text-gray-800 dark:text-neutral-200 hover:bg-gray-50 dark:hover:bg-neutral-800'
+                            ${isFocused && !isSelected
+                              ? 'bg-gray-100 dark:bg-neutral-800'
+                              : isSelected
+                                ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
+                                : 'text-gray-800 dark:text-neutral-200 hover:bg-gray-50 dark:hover:bg-neutral-800'
                             }
                           `}
                         >

--- a/src/components/HistoricalTracking.tsx
+++ b/src/components/HistoricalTracking.tsx
@@ -126,7 +126,7 @@ export const HistoricalTracking = () => {
 
         {/* Currency Selection */}
         <div className="mb-6 flex justify-end">
-          <CurrencySelector size="sm" />
+          <CurrencySelector showLabel={false} />
         </div>
 
         {/* Controls */}

--- a/src/context/CurrencyContext.tsx
+++ b/src/context/CurrencyContext.tsx
@@ -7,20 +7,76 @@ export interface Currency {
   name: string;
   symbol: string;
   locale: string;
+  flag: string;
+  region: string;
 }
 
 export const SUPPORTED_CURRENCIES: Currency[] = [
-  { code: 'USD', name: 'US Dollar', symbol: '$', locale: 'en-US' },
-  { code: 'GBP', name: 'British Pound', symbol: '£', locale: 'en-GB' },
-  { code: 'EUR', name: 'Euro', symbol: '€', locale: 'en-EU' },
-  { code: 'JPY', name: 'Japanese Yen', symbol: '¥', locale: 'ja-JP' },
-  { code: 'CAD', name: 'Canadian Dollar', symbol: 'C$', locale: 'en-CA' },
-  { code: 'AUD', name: 'Australian Dollar', symbol: 'A$', locale: 'en-AU' },
-  { code: 'CHF', name: 'Swiss Franc', symbol: 'CHF', locale: 'de-CH' },
-  { code: 'CNY', name: 'Chinese Yuan', symbol: '¥', locale: 'zh-CN' },
-  { code: 'INR', name: 'Indian Rupee', symbol: '₹', locale: 'en-IN' },
-  { code: 'KRW', name: 'South Korean Won', symbol: '₩', locale: 'ko-KR' },
+  // Americas
+  { code: 'USD', name: 'US Dollar', symbol: '$', locale: 'en-US', flag: '🇺🇸', region: 'Americas' },
+  { code: 'CAD', name: 'Canadian Dollar', symbol: 'C$', locale: 'en-CA', flag: '🇨🇦', region: 'Americas' },
+  { code: 'MXN', name: 'Mexican Peso', symbol: '$', locale: 'es-MX', flag: '🇲🇽', region: 'Americas' },
+  { code: 'BRL', name: 'Brazilian Real', symbol: 'R$', locale: 'pt-BR', flag: '🇧🇷', region: 'Americas' },
+  { code: 'ARS', name: 'Argentine Peso', symbol: '$', locale: 'es-AR', flag: '🇦🇷', region: 'Americas' },
+  { code: 'CLP', name: 'Chilean Peso', symbol: '$', locale: 'es-CL', flag: '🇨🇱', region: 'Americas' },
+  { code: 'COP', name: 'Colombian Peso', symbol: '$', locale: 'es-CO', flag: '🇨🇴', region: 'Americas' },
+  { code: 'PEN', name: 'Peruvian Sol', symbol: 'S/', locale: 'es-PE', flag: '🇵🇪', region: 'Americas' },
+
+  // Europe
+  { code: 'GBP', name: 'British Pound', symbol: '£', locale: 'en-GB', flag: '🇬🇧', region: 'Europe' },
+  { code: 'EUR', name: 'Euro', symbol: '€', locale: 'de-DE', flag: '🇪🇺', region: 'Europe' },
+  { code: 'CHF', name: 'Swiss Franc', symbol: 'CHF', locale: 'de-CH', flag: '🇨🇭', region: 'Europe' },
+  { code: 'NOK', name: 'Norwegian Krone', symbol: 'kr', locale: 'nb-NO', flag: '🇳🇴', region: 'Europe' },
+  { code: 'SEK', name: 'Swedish Krona', symbol: 'kr', locale: 'sv-SE', flag: '🇸🇪', region: 'Europe' },
+  { code: 'DKK', name: 'Danish Krone', symbol: 'kr', locale: 'da-DK', flag: '🇩🇰', region: 'Europe' },
+  { code: 'PLN', name: 'Polish Złoty', symbol: 'zł', locale: 'pl-PL', flag: '🇵🇱', region: 'Europe' },
+  { code: 'CZK', name: 'Czech Koruna', symbol: 'Kč', locale: 'cs-CZ', flag: '🇨🇿', region: 'Europe' },
+  { code: 'HUF', name: 'Hungarian Forint', symbol: 'Ft', locale: 'hu-HU', flag: '🇭🇺', region: 'Europe' },
+  { code: 'RON', name: 'Romanian Leu', symbol: 'lei', locale: 'ro-RO', flag: '🇷🇴', region: 'Europe' },
+  { code: 'RUB', name: 'Russian Ruble', symbol: '₽', locale: 'ru-RU', flag: '🇷🇺', region: 'Europe' },
+  { code: 'TRY', name: 'Turkish Lira', symbol: '₺', locale: 'tr-TR', flag: '🇹🇷', region: 'Europe' },
+
+  // Asia & Pacific
+  { code: 'JPY', name: 'Japanese Yen', symbol: '¥', locale: 'ja-JP', flag: '🇯🇵', region: 'Asia & Pacific' },
+  { code: 'CNY', name: 'Chinese Yuan', symbol: '¥', locale: 'zh-CN', flag: '🇨🇳', region: 'Asia & Pacific' },
+  { code: 'INR', name: 'Indian Rupee', symbol: '₹', locale: 'en-IN', flag: '🇮🇳', region: 'Asia & Pacific' },
+  { code: 'KRW', name: 'South Korean Won', symbol: '₩', locale: 'ko-KR', flag: '🇰🇷', region: 'Asia & Pacific' },
+  { code: 'HKD', name: 'Hong Kong Dollar', symbol: 'HK$', locale: 'zh-HK', flag: '🇭🇰', region: 'Asia & Pacific' },
+  { code: 'SGD', name: 'Singapore Dollar', symbol: 'S$', locale: 'en-SG', flag: '🇸🇬', region: 'Asia & Pacific' },
+  { code: 'TWD', name: 'Taiwan Dollar', symbol: 'NT$', locale: 'zh-TW', flag: '🇹🇼', region: 'Asia & Pacific' },
+  { code: 'THB', name: 'Thai Baht', symbol: '฿', locale: 'th-TH', flag: '🇹🇭', region: 'Asia & Pacific' },
+  { code: 'MYR', name: 'Malaysian Ringgit', symbol: 'RM', locale: 'en-MY', flag: '🇲🇾', region: 'Asia & Pacific' },
+  { code: 'IDR', name: 'Indonesian Rupiah', symbol: 'Rp', locale: 'id-ID', flag: '🇮🇩', region: 'Asia & Pacific' },
+  { code: 'PHP', name: 'Philippine Peso', symbol: '₱', locale: 'en-PH', flag: '🇵🇭', region: 'Asia & Pacific' },
+  { code: 'VND', name: 'Vietnamese Dong', symbol: '₫', locale: 'vi-VN', flag: '🇻🇳', region: 'Asia & Pacific' },
+  { code: 'PKR', name: 'Pakistani Rupee', symbol: '₨', locale: 'en-PK', flag: '🇵🇰', region: 'Asia & Pacific' },
+  { code: 'BDT', name: 'Bangladeshi Taka', symbol: '৳', locale: 'bn-BD', flag: '🇧🇩', region: 'Asia & Pacific' },
+  { code: 'AUD', name: 'Australian Dollar', symbol: 'A$', locale: 'en-AU', flag: '🇦🇺', region: 'Asia & Pacific' },
+  { code: 'NZD', name: 'New Zealand Dollar', symbol: 'NZ$', locale: 'en-NZ', flag: '🇳🇿', region: 'Asia & Pacific' },
+
+  // Middle East
+  { code: 'AED', name: 'UAE Dirham', symbol: 'د.إ', locale: 'ar-AE', flag: '🇦🇪', region: 'Middle East' },
+  { code: 'SAR', name: 'Saudi Riyal', symbol: '﷼', locale: 'ar-SA', flag: '🇸🇦', region: 'Middle East' },
+  { code: 'QAR', name: 'Qatari Riyal', symbol: '﷼', locale: 'ar-QA', flag: '🇶🇦', region: 'Middle East' },
+  { code: 'KWD', name: 'Kuwaiti Dinar', symbol: 'د.ك', locale: 'ar-KW', flag: '🇰🇼', region: 'Middle East' },
+  { code: 'BHD', name: 'Bahraini Dinar', symbol: '.د.ب', locale: 'ar-BH', flag: '🇧🇭', region: 'Middle East' },
+  { code: 'EGP', name: 'Egyptian Pound', symbol: '£', locale: 'ar-EG', flag: '🇪🇬', region: 'Middle East' },
+
+  // Africa
+  { code: 'ZAR', name: 'South African Rand', symbol: 'R', locale: 'en-ZA', flag: '🇿🇦', region: 'Africa' },
+  { code: 'NGN', name: 'Nigerian Naira', symbol: '₦', locale: 'en-NG', flag: '🇳🇬', region: 'Africa' },
+  { code: 'KES', name: 'Kenyan Shilling', symbol: 'KSh', locale: 'sw-KE', flag: '🇰🇪', region: 'Africa' },
+  { code: 'GHS', name: 'Ghanaian Cedi', symbol: '₵', locale: 'en-GH', flag: '🇬🇭', region: 'Africa' },
+  { code: 'MAD', name: 'Moroccan Dirham', symbol: 'د.م.', locale: 'ar-MA', flag: '🇲🇦', region: 'Africa' },
 ];
+
+// Grouping helper
+export const CURRENCY_REGIONS = Array.from(
+  new Set(SUPPORTED_CURRENCIES.map((c) => c.region))
+);
+
+export const getCurrenciesByRegion = (region: string): Currency[] =>
+  SUPPORTED_CURRENCIES.filter((c) => c.region === region);
 
 interface CurrencyContextType {
   selectedCurrency: Currency;
@@ -39,13 +95,15 @@ export const useCurrency = () => {
 };
 
 export const CurrencyProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [selectedCurrency, setSelectedCurrencyState] = useState<Currency>(SUPPORTED_CURRENCIES[1]); // Default to GBP
+  const [selectedCurrency, setSelectedCurrencyState] = useState<Currency>(
+    SUPPORTED_CURRENCIES.find((c) => c.code === 'GBP') ?? SUPPORTED_CURRENCIES[0]
+  );
 
   // Load currency preference from localStorage on mount
   useEffect(() => {
     const savedCurrencyCode = localStorage.getItem('finance-currency');
     if (savedCurrencyCode) {
-      const savedCurrency = SUPPORTED_CURRENCIES.find(currency => currency.code === savedCurrencyCode);
+      const savedCurrency = SUPPORTED_CURRENCIES.find((currency) => currency.code === savedCurrencyCode);
       if (savedCurrency) {
         setSelectedCurrencyState(savedCurrency);
       }
@@ -59,10 +117,15 @@ export const CurrencyProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   };
 
   const formatCurrency = (amount: number): string => {
-    return new Intl.NumberFormat(selectedCurrency.locale, {
-      style: 'currency',
-      currency: selectedCurrency.code,
-    }).format(amount);
+    try {
+      return new Intl.NumberFormat(selectedCurrency.locale, {
+        style: 'currency',
+        currency: selectedCurrency.code,
+      }).format(amount);
+    } catch {
+      // Fallback if the locale/code combo is unsupported by the runtime
+      return `${selectedCurrency.symbol}${amount.toFixed(2)}`;
+    }
   };
 
   return (


### PR DESCRIPTION
- Added 47 currencies from around the world, each with a flag and grouped by region (Americas, Europe, Asia & Pacific, Middle East, Africa)
- Replaced the plain dropdown with a searchable picker  type a country name, currency code, or symbol to filter instantly
- Added region filter tabs with smooth scroll arrows so you can browse by area without hunting through a long list
- Tags fade out gracefully as they slide under the scroll arrows, giving the whole thing a clean and polished feel